### PR TITLE
Add gamePaths keyed by GameStore

### DIFF
--- a/projects/pydt-shared-lib/package.json
+++ b/projects/pydt-shared-lib/package.json
@@ -1,4 +1,4 @@
 {
   "name": "pydt-shared",
-  "version": "1.3.6"
+  "version": "1.4.0"
 }

--- a/projects/pydt-shared-lib/src/model/civ6defs.ts
+++ b/projects/pydt-shared-lib/src/model/civ6defs.ts
@@ -188,6 +188,11 @@ export const CIV6_GAME: CivGame = {
         [Platform.OSX]: { basePath: BasePath.APP_DATA, prefix: '' },
         [Platform.Linux]: { basePath: BasePath.HOME, prefix: '/.local/share/aspyr-media' }
     },
+    gamePaths: {
+        [GameStore.Epic]: '/Sid Meier\'s Civilization VI (Epic)/',
+        [GameStore.Steam]: '/Sid Meier\'s Civilization VI/'
+    },
+    savePath: '/Saves/Hotseat/',
     saveDirectory: '/Sid Meier\'s Civilization VI/Saves/Hotseat/',
     saveExtension: 'Civ6Save',
     steamRunUrl: 'steam://run/289070/\\dx11'

--- a/projects/pydt-shared-lib/src/model/civdefs.ts
+++ b/projects/pydt-shared-lib/src/model/civdefs.ts
@@ -9,6 +9,8 @@ export interface CivGame {
   mapSizes: MapSize[];
   maps: Map[];
   saveLocations: { [key in Platform]: PlatformSaveLocation };
+  gamePaths: { [key in GameStore]: string };
+  savePath: string;
   saveDirectory: string;
   saveExtension: string;
   steamRunUrl: string;
@@ -18,6 +20,11 @@ export enum Platform {
   Windows = 'win32',
   OSX = 'darwin',
   Linux = 'linux'
+}
+
+export enum GameStore {
+  Epic = 'epic',
+  Steam = 'steam'
 }
 
 export enum BasePath {


### PR DESCRIPTION
Part of https://github.com/pydt/client/issues/38

Why:

* The Civ6 game directory is stored in a different directory if it was purchased on the
  Epic Game Store (CIV6 is free on Epic now).

This change addresses the need by:

* Adds `GameStore` enum to represent store.  It also adds the
  different game directory paths in `CIV6_GAME`.  `SavePath` is added
  for the path from the game directory to not change `saveDirectory` and
  break backward compatibility. This can be used by the client to add
  some basic support in CIV6, e.g. If Epic Game directory exists, save
  to there instead.