### PR TITLE
Fix pydt/client#56

### DIFF
--- a/projects/pydt-shared-lib/src/lib/player-avatar/player-avatar.component.css
+++ b/projects/pydt-shared-lib/src/lib/player-avatar/player-avatar.component.css
@@ -1,5 +1,5 @@
 .currentTurn {
-  background-color: #ccffcc;
+  background-color: #30875E;
 }
 
 .dragMode {


### PR DESCRIPTION
Changing the current turn color to something with a better contrast ratio. One of the shades of green in the PYDT logo was perfect.